### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.0.8
 Date: 2021-02-15
 Depends: R (>= 2.10), tcltk, igraph
 Imports: e1071, fgui, grDevices, graphics, googleVis, maptools, rgeos,
-        rgrass7, raster, spatstat.geom, spatstat.core, stats, sp, minpack.lm, zipfR, coda,
+        rgrass7, raster, spatstat.geom, spatstat.random, stats, sp, minpack.lm, zipfR, coda,
         knitr
 Suggests: rasterVis
 Author: Frederico Mestre, Fernando Canovas, Benjamin Risk, Ricardo Pita, 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -46,8 +46,8 @@ export(accept.calculate,
 
 #####################################
 ##              Imports            ##
-#####################################       
-       
+#####################################
+
 import("tcltk")
 import("igraph")
 
@@ -72,7 +72,7 @@ importFrom(spatstat.geom,  as.ppp)
 importFrom(spatstat.geom,  nndist)
 importFrom(spatstat.geom,  npoints)
 importFrom(spatstat.geom,  owin)
-importFrom(spatstat.core,  rSSI)
+importFrom(spatstat.random,  rSSI)
 importFrom(spatstat.geom,  pairdist)
 importFrom(spatstat.geom,  coords)
 
@@ -81,6 +81,6 @@ importFrom(spatstat.geom,  coords)
 ################################
 #exportClasses("metapopulation",
 #              "landscape",
-#              "expansion")           
+#              "expansion")
 
 


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`. This should hopefully fix the problem for your package.